### PR TITLE
Add option to force creation of manual enrollment

### DIFF
--- a/import.php
+++ b/import.php
@@ -148,13 +148,15 @@
                         ? 0 : intval($formdata->{local_userenrols_plugin::FORMID_GROUP_ID});
         $group_create   = empty($formdata->{local_userenrols_plugin::FORMID_GROUP_CREATE})
                         ? 0 : intval($formdata->{local_userenrols_plugin::FORMID_GROUP_CREATE});
+        $force          = empty($formdata->{local_userenrols_plugin::FORMID_ENROLL_FORCE_CREATE})
+                        ? 0 : intval($formdata->{local_userenrols_plugin::FORMID_ENROLL_FORCE_CREATE});
 
         // Leave the file in the user's draft area since we
         // will not plan to keep it after processing
         $area_files = get_file_storage()->get_area_files($user_context->id, 'user', 'draft', $formdata->{local_userenrols_plugin::FORMID_FILES}, null, false);
         $result = local_userenrols_plugin::import_file($COURSE, $manual_enrol_instance,
             $user_id_field, $role_id, $canmanagegroups ? (boolean)$group_assign : false,
-            $group_id, (boolean)$group_create, array_shift($area_files));
+            $group_id, (boolean)$group_create, array_shift($area_files), (boolean)$force);
 
         // Clean up the file area
         get_file_storage()->delete_area_files($user_context->id, 'user', 'draft', $formdata->{local_userenrols_plugin::FORMID_FILES});

--- a/import_form.php
+++ b/import_form.php
@@ -77,6 +77,10 @@
             $this->_form->addHelpButton(local_userenrols_plugin::FORMID_ROLE_ID, 'LBL_ROLE_ID', local_userenrols_plugin::PLUGIN_NAME);
             $this->_form->disabledIf(local_userenrols_plugin::FORMID_ROLE_ID, local_userenrols_plugin::FORMID_METACOURSE, 'eq', '1');
 
+            // Force new manual enrolment creation
+            $this->_form->addElement('selectyesno', local_userenrols_plugin::FORMID_ENROLL_FORCE_CREATE, get_string('LBL_ENROLL_FORCE_CREATE', local_userenrols_plugin::PLUGIN_NAME));
+            $this->_form->setDefault(local_userenrols_plugin::FORMID_ENROLL_FORCE_CREATE, 0);
+            $this->_form->addHelpButton(local_userenrols_plugin::FORMID_ENROLL_FORCE_CREATE, 'LBL_ENROLL_FORCE_CREATE', local_userenrols_plugin::PLUGIN_NAME);
 
             // Conditionally based on user capability
             if ($this->_customdata['data']->canmanagegroups) {

--- a/lang/en/local_userenrols.php
+++ b/lang/en/local_userenrols.php
@@ -40,6 +40,8 @@
     $string['LBL_IMPORT']               = 'Import';
     $string['LBL_IDENTITY_OPTIONS']     = 'User Identity';
     $string['LBL_ENROLL_OPTIONS']       = 'Enrollment Options';
+    $string['LBL_ENROLL_FORCE_CREATE']  = 'Force creation of new manual enrollment';
+    $string['LBL_ENROLL_FORCE_CREATE_help'] = 'If set to yes, a new manual enrollment will be created regardless of whether or not the user has an existing role in the course.';
     $string['LBL_GROUP_OPTIONS']        = 'Group Options';
     $string['LBL_FILE_OPTIONS']         = 'Import File';
     $string['LBL_FILE_OPTIONS_help']    = 'Upload or pick from a repository a delimited data file with user and optional group information. File should have either a .txt or .csv extension.';

--- a/lib.php
+++ b/lib.php
@@ -107,6 +107,11 @@
         const FORMID_ROLE_ID              = 'role_id';
 
         /**
+         * @const string    Form id for enroll_force_create.
+         */
+        const FORMID_ENROLL_FORCE_CREATE        = 'enrol_force_create';
+
+        /**
          * @const string    Form id for user_id (key field to match).
          */
         const FORMID_USER_ID_FIELD        = 'user_id';
@@ -196,7 +201,17 @@
          *
          * @uses $DB
          */
-        public static function import_file(stdClass $course, stdClass $enrol_instance, $ident_field, $role_id, $group_assign, $group_id, $group_create, stored_file $import_file)
+        public static function import_file(
+            stdClass $course,
+            stdClass $enrol_instance,
+            $ident_field,
+            $role_id,
+            $group_assign,
+            $group_id,
+            $group_create,
+            stored_file $import_file,
+            bool $forcemanualenrollment = false
+        )
         {
             global $DB;
 
@@ -310,7 +325,7 @@
                 // If a user has a role in this course, then we leave it alone and move on
                 // to the group assignment if there is one. If they have no role, then we
                 // should go ahead and add one, as long as it is not a metacourse.
-                if (!$roles && $role_id > 0) {
+                if ((!$roles && $role_id > 0) || $forcemanualenrollment) {
                     if ($metacourse) {
                         $result .= sprintf(get_string('ERR_ENROLL_META', self::PLUGIN_NAME), $line_num, $ident_value);
                     } else {

--- a/version.php
+++ b/version.php
@@ -32,7 +32,7 @@
 
     $plugin             = new stdClass();
 
-    $plugin->version    = 2018052010;
+    $plugin->version    = 2022012000;
     $plugin->requires   = 2017111300;
     $plugin->release    = "0.0.10_34 (Build 2021053100)";
     $plugin->component  = 'local_userenrols';


### PR DESCRIPTION
In some situations it may be desirable to create a new manual enrollment. For example if students are enrolled using an external database and that enrollment is suspended, a teacher may want to bulk enroll them all with a manual enrollment. This patch adds an option to allow the manual enrollment to be created even if a student already has a role in the course.